### PR TITLE
Add JK_builder

### DIFF
--- a/quest/core/CMakeLists.txt
+++ b/quest/core/CMakeLists.txt
@@ -21,3 +21,5 @@ set(CMAKE_CXX_FLAGS "-fopenmp")
 
 find_package(TargetLAPACK REQUIRED)
 target_link_libraries(core PRIVATE tgt::lapack)
+
+pybind11_add_module(JK_builder_C MODULE JK_builder_C.cpp)

--- a/quest/core/JK_builder_C.cpp
+++ b/quest/core/JK_builder_C.cpp
@@ -1,0 +1,201 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <string>
+#include <iostream>
+#include <omp.h>
+
+namespace py = pybind11;
+
+std::vector<py::array> form_JK_conventional(py::array_t<double> I, py::array_t<double> D)
+{
+    py::buffer_info I_info = I.request();
+    py::buffer_info D_info = D.request();
+    
+    if(I_info.ndim != 4) throw std::runtime_error("I is not a rank-4 tensor");
+    if(D_info.ndim != 2) throw std::runtime_error("D is not a matrix");
+
+    size_t dim = D_info.shape[0];
+    size_t dim2 = dim*dim;
+    size_t dim3 = dim*dim2;
+    
+    const double * I_data = static_cast<double *>(I_info.ptr);
+    const double * D_data = static_cast<double *>(D_info.ptr);
+    
+    std::vector<double> J_data(dim * dim);
+    std::vector<double> K_data(dim * dim);
+
+    #pragma omp parallel for num_threads(4) schedule(dynamic)
+    for(size_t p = 0; p < dim; p++)
+    {
+        for(size_t q = 0; q <= p; q++)
+        {
+            double Jvalue = 0.;
+            double Kvalue = 0.;
+            for(size_t r = 0; r < dim; r++)
+            {
+                for(size_t s = 0; s < r; s++)
+                {
+                    Jvalue += 2.*I_data[p * dim3 + q * dim2 + r * dim + s] * D_data[r * dim + s];
+                }
+                Jvalue += I_data[p * dim3 + q * dim2 + r * dim + r] * D_data[r * dim + r];
+                for(size_t i = 0; i < dim; i++)
+                {
+                    Kvalue += I_data[p * dim3 + r * dim2 + q * dim + i] * D_data[r * dim + i];
+                }
+            }
+            J_data[p * dim + q] = Jvalue;
+            J_data[q * dim + p] = Jvalue;
+            K_data[p * dim + q]	= Kvalue;
+            K_data[q * dim + p]	= Kvalue;            
+        }
+    }
+    
+    py::buffer_info Jbuf =
+    {
+        J_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {dim, dim},
+        {dim * sizeof(double), sizeof(double)}
+    };
+    
+    py::buffer_info Kbuf =
+    {
+        K_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {dim, dim},
+        {dim * sizeof(double), sizeof(double)}
+    };
+    
+    py::array J(Jbuf);
+    py::array K(Kbuf);
+    return {J, K};
+}
+
+std::vector<py::array> form_JK_df(py::array_t<double> Ig, py::array_t<double> D,  py::array_t<double> C)
+{
+    py::buffer_info Ig_info = Ig.request();
+    py::buffer_info D_info = D.request();
+    py::buffer_info C_info = C.request();
+    
+    if(Ig_info.ndim != 3) throw std::runtime_error("I is not a rank-3 tensor");
+    if(D_info.ndim != 2) throw std::runtime_error("D is not a matrix");
+
+    size_t dimD = D_info.shape[0];
+    size_t dimIg = Ig_info.shape[0];
+    
+	const double * Ig_data = static_cast<double *>(Ig_info.ptr);
+    const double * D_data = static_cast<double *>(D_info.ptr);
+    const double * C_data = static_cast<double *>(C_info.ptr);
+
+    std::vector<double> kaiP_data(dimIg);
+    std::vector<double> zeta_data(dimIg * dimD * dimD);
+    
+    std::vector<double> J_data(dimD * dimD);
+    std::vector<double> K_data(dimD * dimD);
+
+std::cout<< "dimIg " << dimIg << std::endl;	
+std::cout<< "dimD " << dimD << std::endl;	
+std::cout<< Ig_info.shape[0] << Ig_info.shape[1] << Ig_info.shape[2] << std::endl;	
+	
+	
+   // #pragma omp parallel for num_threads(4) schedule(dynamic)
+    for(size_t p = 0; p < dimIg; p++)
+    {
+        double value = 0.;
+        for(size_t l = 0; l < dimD; l++)
+        {
+            for(size_t s = 0; s < dimD; s++)
+            {
+			//	std::cout << p << " " << l << " " << s << std::endl;
+                value += Ig_data[p * dimIg * dimD + l * dimD + s] * D_data[l * dimD + s];
+                value += Ig_data[p * dimIg * dimD + l * dimD + s] * D_data.at(l * dimD + s);
+            }
+        }
+        kaiP_data[p] = value;
+    }
+/*    #pragma omp parallel for num_threads(4) schedule(dynamic)
+    for(size_t l = 0; l < dimD; l++)
+    {
+        for(size_t s = 0; s <= l; s++)
+        {
+            double value = 0.;
+            for(size_t p = 0; p < dimIg; p++)
+            {
+                value += Ig_data[p * dimIg * dimD + l * dimD + s] * kaiP_data[p];
+            }
+            J_data[l * dimD + s] = value;
+            J_data[s * dimD + l] = value;
+        }
+    }*/
+#if 0
+    #pragma omp parallel for num_threads(4) schedule(dynamic)
+    for(size_t p = 0; p < dimIg; p++)
+    {
+        for(size_t l = 0; l < dimD; l++)
+        {
+            for(size_t m = 0; m < dimD; m++)
+            {
+                double value = 0.;
+                for(size_t s = 0; s < dimD; s++)
+                {
+                    value += Ig_data[p * dimIg * dimD + l * dimD + s] * C_data[m * dimD + s];
+                }
+                zeta_data[p * dimIg * dimD + l * dimD + m] = value;
+            }
+        }
+    }
+    #pragma omp parallel for num_threads(4) schedule(dynamic)
+    for(size_t l = 0; l < dimD; l++)
+    {
+        for(size_t s = 0; s <= l; s++)
+        {
+            double value = 0.;
+            for(size_t p = 0; p < dimIg; p++)
+            {
+                for(size_t r = 0; r < dimD; r++)
+                {
+                    value += zeta_data[p * dimIg * dimD + l * dimD + r] * zeta_data[p * dimIg * dimD + s * dimD + r];
+                }
+            }
+            K_data[l * dimD + s] = value;
+            K_data[s * dimD + l] = value;
+        }
+    }
+#endif
+    py::buffer_info Jbuf =
+    {
+        J_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {dimD, dimD},
+        {dimD * sizeof(double), sizeof(double)}
+    };
+    
+    py::buffer_info Kbuf =
+    {
+        K_data.data(),
+        sizeof(double),
+        py::format_descriptor<double>::format(),
+        2,
+        {dimD, dimD},
+        {dimD * sizeof(double), sizeof(double)}
+    };
+    
+    py::array J(Jbuf);
+    py::array K(Kbuf);
+    return {J, K};
+}
+
+PYBIND11_PLUGIN(JK_builder_C)
+{
+    py::module m("JK_builder_C", "Computes J and K");
+    m.def("form_JK_conventional", &form_JK_conventional, "Computes J and K using conventional method");
+    m.def("form_JK_df", &form_JK_df, "Computes J and K using density fitting");
+    return m.ptr();
+}

--- a/quest/jk.py
+++ b/quest/jk.py
@@ -1,78 +1,42 @@
-"""
-Contains the JK computers (or their bindings)
-"""
-from . import core
-
+import JK_builder_C
 import numpy as np
 import psi4
 
 
-def build_JK(mints, jk_type, auxiliary=None):
-    """
-    Construct a JK object of various types with the given specifications.
+def __init__(self):
+	pass
 
-    Parameters
-    ----------
-    mints : psi4.core.MintsHelper
-        Psi4 BasisSet object
-    jk_type : str (PK,)
-        The type of JK object to construct
-    auxiliary : psi4.core.BasisSet (None)
-        The auxiliary basis for DF computations
+def by_conventional(I, D):
+	return JK_builder_C.form_JK_conventional(I, D)
+	 
+def by_df(Ig, D, C):
+	return JK_builder_C.form_JK_df(Ig, D, C)
 
-    Returns
-    -------
-    jk_object : JK
-        A initialized JK object
-
-    Notes
-    -----
-    For DF the basis is automatically constructed as the complementary JK object.
-
-    Examples
-    --------
-
-    jk = build_JK(mints, "PK")
-    J, K = jk.compute_JK(C_left)
-    ...
-
-    """
-
-    if jk_type == "PK":
-        return PKJK(mints)
-    else:
-        raise KeyError("build_JK: Unknown JK type '%s'" % jk_type)
-
-
-class PKJK(object):
-    """
-    Constructs a "PK" JK object. This effectively holds two supermatrices which the inner product is
-    then taken for speed.
-
-    J_pq[D_rs] = I_prqs D_rs
-    K_pq[D_rs] = I_pqrs D_rs
-
-    """
-
-    def __init__(self, mints):
-        """
-        Initialized the JK object from a MintsHelper object.
-        """
-        self.nbf = mints.nbf()
-        self.I = np.asarray(mints.ao_eri())
-
-    def compute_JK(self, C_left, C_right=None):
-        """
-        Compute the J and K matrices for Cocc orbitals
-        """
-
-        if C_right is None:
-            C_right = C_left
-
-        D = np.dot(C_right, C_left.T)
-
-        J = np.zeros((self.nbf, self.nbf))
-        K = np.zeros((self.nbf, self.nbf))
-        core.compute_PKJK(self.I, D, J, K)
-
-        return J, K
+def calc_Ig(bas, mol, basname):
+	'''mints = psi4.core.MintsHelper(orb)
+	aux = psi4.core.BasisSet.build(mol, fitrole="JKFIT", other=basname)
+	zero_bas = psi4.core.BasisSet.zero_ao_basis_set()
+	Qls_tilde = mints.ao_eri(zero_bas, aux, orb, orb)
+	Qls_tilde = np.squeeze(Qls_tilde)
+	metric = mints.ao_eri(zero_bas, aux, zero_bas, aux)
+	metric.power(-0.5, 1.e-14)
+	metric = np.squeeze(metric)
+	Pls = np.einsum('pq,qls->pls', metric, Qls_tilde)'''
+	# Build the complementary JKFIT basis for the aug-cc-pVDZ basis (for example)
+	aux = psi4.core.BasisSet.build(mol, fitrole="JKFIT", other="aug-cc-pVDZ")
+	# The zero basis set
+	zero_bas = psi4.core.BasisSet.zero_ao_basis_set()
+	# Build instance of MintsHelper
+	mints = psi4.core.MintsHelper(bas)
+	# Build (P|pq) raw 3-index ERIs, dimension (1, Naux, nbf, nbf)
+	Qls_tilde = mints.ao_eri(zero_bas, aux, bas, bas)
+	Qls_tilde = np.squeeze(Qls_tilde) # remove the 1-dimensions
+	# Build & invert Coulomb metric, dimension (1, Naux, 1, Naux)
+	metric = mints.ao_eri(zero_bas, aux, zero_bas, aux)
+	metric.power(-0.5, 1.e-14)
+	metric = np.squeeze(metric) # remove the 1-dimensions
+	#TODO convert all einsums into np.dots to make code faster
+	# Compute (P|ls)
+	Pls = np.einsum('pq,qls->pls', metric, Qls_tilde)	
+	
+	return Pls

--- a/tests/test_jk.py
+++ b/tests/test_jk.py
@@ -6,6 +6,7 @@ import quest
 import pytest
 import psi4
 import numpy as np
+import jk
 
 psi4.set_output_file("output.dat", True)
 
@@ -28,6 +29,6 @@ H 1 1.1 2 104
     J_ref = np.einsum("pqrs,rs->pq", I, D)
     K_ref = np.einsum("prqs,rs->pq", I, D)
 
-    J, K = jk.compute_JK(Cocc)
+    J, K = jk.by_conventional(I, D)
     assert np.allclose(J_ref, J)
     assert np.allclose(K_ref, K)


### PR DESCRIPTION
We have created a JK_builder which is ready to compute J and K using OpenMP-parallelized core.

Example:
```
import jk
# I: molecular repulsion integrals
# D: density matrix
J, K = jk.by_conventional(I, D)
```

jk.by_df is still in development.