### PR TITLE
Modified aux basis set name

### DIFF
--- a/quest/jk.py
+++ b/quest/jk.py
@@ -91,7 +91,7 @@ class DFJK(object):
         self.nbf = mints.nbf()
         self.I = np.asarray(mints.ao_eri())        
         # Build the complementary JKFIT basis for the aug-cc-pVDZ basis (for example)
-        aux = psi4.core.BasisSet.build(mol, fitrole="JKFIT", other="aug-cc-pVDZ")
+        aux = psi4.core.BasisSet.build(mol, fitrole="JKFIT", other=basname)
         # The zero basis set
         zero_bas = psi4.core.BasisSet.zero_ao_basis_set()
         # Build instance of MintsHelper


### PR DESCRIPTION
* Change the 
```
aux = psi4.core.BasisSet.build(mol, fitrole="JKFIT", other="aug-cc-pvDZ")
```
to 
```
aux = psi4.core.BasisSet.build(mol, fitrole="JKFIT", other=basname)
```

in order to fit more basis sets.

* The JK_builder can be called by `import core`